### PR TITLE
Ensure explicit integer parsing for service counts

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,0 +1,22 @@
+function toInt(value) {
+  const n = parseInt(value, 10);
+  return isNaN(n) ? 0 : n;
+}
+
+function addBookingRow(data) {
+  const sheet = SpreadsheetApp.getActive().getSheetByName('Bookings');
+  const mezuzotCount = toInt(data.mezuzotCount);
+  const tefillinCount = toInt(data.tefillinCount);
+  sheet.appendRow([
+    data.bookingDate,
+    data.time,
+    data.name,
+    data.email,
+    data.phone,
+    data.notes,
+    data.mezuzot,
+    mezuzotCount,
+    data.tefillin,
+    tefillinCount,
+  ]);
+}


### PR DESCRIPTION
## Summary
- Add `Code.gs` backend script with `addBookingRow` and `toInt` helper for explicit decimal parsing
- Use `data.mezuzotCount` and `data.tefillinCount` properties when appending bookings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8358da130832aa714af3891b4c709